### PR TITLE
Fix error when posts are from several months ago

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -94,7 +94,7 @@ exports.timestamp = function (date) {
 
   if (interval >= 1) {
     if (interval >= 3) {
-      return date.toLocaleDateString()
+      return (new Date(date)).toLocaleDateString()
     }
     return interval + 'mo ago'
   }


### PR DESCRIPTION
When trying to use my rotonde profile on fritter I was running into this error from older posts. It was erroring on on `.toLocalDateString()` as at this point in the code the date is still a number.