### PR TITLE
Fix issue of New Post being on top of header

### DIFF
--- a/com/layout/header.less
+++ b/com/layout/header.less
@@ -1,6 +1,6 @@
 header {
   position: fixed;
-  z-index: 3;
+  z-index: 6;
   width: 100%;
   height: 47px;
   background: #fff;


### PR DESCRIPTION
I noticed that the "New Post" are is on top of the header. This PR makes sure that the header is above it.

![screen shot 2018-08-07 at 3 55 07 pm](https://user-images.githubusercontent.com/5623786/43803512-a7aefcd8-9a5e-11e8-80b7-739560264053.png)
