### PR TITLE
Respect line breaks in bio

### DIFF
--- a/com/profile/profile-card.less
+++ b/com/profile/profile-card.less
@@ -26,5 +26,6 @@
     padding-top: 10px;
     border-top: 1px solid #e6ecf0;
     font-size: .85rem;
+    white-space: pre-line;
   }
 }


### PR DESCRIPTION
Currently, when you add line breaks in your profile bio, they're not displayed in the app interface. This PR solves this, using the same CSS-only implementation that is used for posts.