### PR TITLE
Tweak copyProfileUrl to give user a shareable link where the user's profile can be viewed

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -673,7 +673,7 @@ module.exports = class FritterApp {
   }
 
   copyProfileUrl () {
-    var profileUrl = document.getElementById('profile-url')
+    var profileUrl = `${window.location.origin}/user/${document.getElementById('profile-url')}`
     profileUrl.select()
     document.execCommand('copy')
   }

--- a/lib/app.js
+++ b/lib/app.js
@@ -673,7 +673,7 @@ module.exports = class FritterApp {
   }
 
   copyProfileUrl () {
-    var profileUrl = `${window.location.origin}/user/${document.getElementById('profile-url')}`
+    var profileUrl = `${window.location.origin}/user/${document.getElementById('profile-url').replace('dat://','')}`
     profileUrl.select()
     document.execCommand('copy')
   }


### PR DESCRIPTION
When I first started using Fritter, I got stuck trying to figure out how to share my fritter profile and how other users would subscribe to me. This PR will result in the copied profile URL going from a copied URL of `dat://a8d566b635fd219085a0c7e9e9c57f5bed3e6717eca230883631b8079fae4bba` to `dat://fritter.hashbase.io/user/a8d566b635fd219085a0c7e9e9c57f5bed3e6717eca230883631b8079fae4bba` which is something I can share. This seems like the expected behavior to me, I won't take offense if that's not the case for others in which case this PR can be closed.

Related: https://github.com/beakerbrowser/fritter/issues/36